### PR TITLE
ci: adding test commands back in

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python {{ python }}
     - pandas {{ pandas }}
     - numpy
-    - deblur >=1.0.4
+    - deblur >=1.1.2
     - click >=8.1
     - vsearch
     - qiime2 {{ qiime2_epoch }}.*

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python {{ python }}
     - pandas {{ pandas }}
     - numpy
-    - deblur >=1.1.2
+    - deblur >=1.1.1
     - click >=8.1
     - vsearch
     - qiime2 {{ qiime2_epoch }}.*

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -38,10 +38,8 @@ test:
     - q2_deblur
     - qiime2.plugins.deblur
 
-  # uncomment and remove run_test.sh when 1.1.2 lands (which should include:
-  # https://github.com/biocore/deblur/pull/216)
-  # commands:
-  #   - pytest --pyargs deblur
+  commands:
+    - pytest --pyargs deblur
 
 about:
   home: https://qiime2.org

--- a/ci/recipe/run_test.sh
+++ b/ci/recipe/run_test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-git clone https://github.com/biocore/deblur deblur-upstream
-nosetests --with-doctest deblur-upstream
-rm -rf deblur-upstream


### PR DESCRIPTION
This PR reverts the commented out test commands from #91, since [this PR](https://github.com/biocore/deblur/pull/216) has been merged.