### PR TITLE
ci: adding q2_deblur tests

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -42,7 +42,6 @@ test:
   # https://github.com/biocore/deblur/pull/216)
   # commands:
   #   - pytest --pyargs deblur
-  additional-tests: py.test --pyargs q2_deblur
 
 about:
   home: https://qiime2.org

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
   # https://github.com/biocore/deblur/pull/216)
   # commands:
   #   - pytest --pyargs deblur
+  additional-tests: py.test --pyargs q2_deblur
 
 about:
   home: https://qiime2.org

--- a/ci/recipe/run_test.sh
+++ b/ci/recipe/run_test.sh
@@ -3,3 +3,7 @@
 git clone https://github.com/biocore/deblur deblur-upstream
 nosetests --with-doctest deblur-upstream
 rm -rf deblur-upstream
+
+git clone https://github.com/qiime2/q2-deblur q2_deblur
+py.test --pyargs q2_deblur
+rm -rf q2_deblur

--- a/ci/recipe/run_test.sh
+++ b/ci/recipe/run_test.sh
@@ -4,6 +4,5 @@ git clone https://github.com/biocore/deblur deblur-upstream
 nosetests --with-doctest deblur-upstream
 rm -rf deblur-upstream
 
-git clone https://github.com/qiime2/q2-deblur q2_deblur
 py.test --pyargs q2_deblur
 rm -rf q2_deblur

--- a/ci/recipe/run_test.sh
+++ b/ci/recipe/run_test.sh
@@ -5,4 +5,3 @@ nosetests --with-doctest deblur-upstream
 rm -rf deblur-upstream
 
 py.test --pyargs q2_deblur
-rm -rf q2_deblur


### PR DESCRIPTION
this PR adds the additional-tests command in the recipe file so that q2-deblur's unit tests are actually being run on ci.