### PR TITLE
DEP: pins vsearch to resolve test failure

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - deblur >=1.0.4
     - click >=8.1
-    - vsearch >2.23.0
+    - vsearch <2.23.0
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy
     - deblur >=1.0.4
     - click >=8.1
-    - vsearch
+    - vsearch >2.23.0
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*


### PR DESCRIPTION
Adds a max pin on vsearch to resolve the `test_with_stats` test failure shown below.
![Screen Shot 2023-08-14 at 10 01 18 AM](https://github.com/qiime2/q2-deblur/assets/54517601/2c652670-9e95-4f45-8db3-960dbdcd8b99)
